### PR TITLE
Invalid character replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.2.1 (2020-05-13)
+* Add `InvalidCharReplacement` variable
 
 ## 0.2.0 (2016-08-14)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 go-slugify
 ==============
 
-[![Build Status](https://travis-ci.org/mozillazg/go-slugify.svg?branch=master)](https://travis-ci.org/mozillazg/go-slugify)
-[![Coverage Status](https://coveralls.io/repos/mozillazg/go-slugify/badge.svg?branch=master)](https://coveralls.io/r/mozillazg/go-slugify?branch=master)
-[![Go Report Card](https://goreportcard.com/badge/github.com/mozillazg/go-slugify)](https://goreportcard.com/report/github.com/mozillazg/go-slugify)
-[![GoDoc](https://godoc.org/github.com/mozillazg/go-slugify?status.svg)](https://godoc.org/github.com/mozillazg/go-slugify)
+[![Build Status](https://travis-ci.org/shopsmart/go-slugify.svg?branch=master)](https://travis-ci.org/shopsmart/go-slugify)
+[![Coverage Status](https://coveralls.io/repos/shopsmart/go-slugify/badge.svg?branch=master)](https://coveralls.io/r/shopsmart/go-slugify?branch=master)
+[![Go Report Card](https://goreportcard.com/badge/github.com/shopsmart/go-slugify)](https://goreportcard.com/report/github.com/shopsmart/go-slugify)
+[![GoDoc](https://godoc.org/github.com/shopsmart/go-slugify?status.svg)](https://godoc.org/github.com/shopsmart/go-slugify)
 
 Make Pretty Slug.
 
@@ -13,15 +13,15 @@ Installation
 ------------
 
 ```
-go get -u github.com/mozillazg/go-slugify
+go get -u github.com/shopsmart/go-slugify
 ```
 
 Install CLI tool:
 
 ```
-go get -u github.com/mozillazg/go-slugify/slugify
-$ slugify "北京kožušček,abc"
-bei-jing-kozuscek-abc
+go get -u github.com/shopsmart/go-slugify/slugify
+$ slugify "Brad's Deals & abc"
+brads-deals-abc
 ```
 
 
@@ -40,12 +40,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/mozillazg/go-slugify"
+	"github.com/shopsmart/go-slugify"
 )
 
 func main() {
-	s := "北京kožušček,abc"
+	s := "Brad's Deals & abc"
 	fmt.Println(slugify.Slugify(s))
-	// Output: bei-jing-kozuscek-abc
+	// Output: brads-deals-abc
 }
 ```

--- a/example_test.go
+++ b/example_test.go
@@ -3,11 +3,11 @@ package slugify_test
 import (
 	"fmt"
 
-	"github.com/mozillazg/go-slugify"
+	"github.com/shopsmart/go-slugify"
 )
 
 func ExampleSlugify() {
-	s := "Nín hǎo. Wǒ shì zhōng guó rén This is a test ---"
+	s := "Nín hǎo. Wǒ shì zhōng guó rén This is a test, Brad's Deals ---"
 	fmt.Println(slugify.Slugify(s))
-	// Output: nin-hao-wo-shi-zhong-guo-ren-this-is-a-test
+	// Output: nin-hao-wo-shi-zhong-guo-ren-this-is-a-test-brads-deals
 }

--- a/slugify.go
+++ b/slugify.go
@@ -11,6 +11,9 @@ import (
 // Separator separator between words
 var Separator = "-"
 
+// InvalidCharReplacement replaces invalid characters
+var InvalidCharReplacement = ""
+
 // SeparatorForRe for regexp
 var SeparatorForRe = regexp.QuoteMeta(Separator)
 
@@ -33,7 +36,7 @@ func Slugify(s string) string {
 
 func slugify(s string) string {
 	s = unidecode.Unidecode(s)
-	s = replaceInValidCharacter(s, Separator)
+	s = replaceInValidCharacter(s, InvalidCharReplacement)
 	s = removeDupSeparator(s)
 	s = strings.Trim(s, Separator)
 	s = strings.ToLower(s)

--- a/slugify.go
+++ b/slugify.go
@@ -25,7 +25,7 @@ var ReDupSeparatorChar = regexp.MustCompile(fmt.Sprintf("%s{2,}", SeparatorForRe
 
 // Version return version
 func Version() string {
-	return "0.2.0"
+	return "0.2.1"
 }
 
 // Slugify implements make a pretty slug from the given text.

--- a/slugify/main.go
+++ b/slugify/main.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/mattn/go-isatty"
-	"github.com/mozillazg/go-slugify"
+	"github.com/shopsmart/go-slugify"
 )
 
 func main() {

--- a/slugify_test.go
+++ b/slugify_test.go
@@ -1,7 +1,9 @@
 package slugify
 
-import "testing"
-import "log"
+import (
+	"log"
+	"testing"
+)
 
 type testCase struct {
 	input, expect string
@@ -35,6 +37,7 @@ func TestSlugify(t *testing.T) {
 		{"北京kožušček", "bei-jing-kozuscek"},
 		{"Nín hǎo. Wǒ shì zhōng guó rén", "nin-hao-wo-shi-zhong-guo-ren"},
 		{`C\'est déjà l\'été.`, "c-est-deja-l-ete"},
+		{`Brad's Deals`, "brads-deals"},
 	}
 	for _, c := range cases {
 		log.Printf("input %v, expect %v", c.input, c.expect)


### PR DESCRIPTION
Add `InvalidCharReplacement` variable so separators and invalid characters can remain separate configurations.